### PR TITLE
updating version to 0.4.0

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -5,7 +5,7 @@
 
 # Change this to the version of Ghost you want to install.
 # Untested with versions outside of 0.3.2.
-VERSION=0.3.2
+VERSION=0.4.0
 
 # Only run the following if this is the first time running.
 if [ ! -f /var/log/firsttime ]


### PR DESCRIPTION
Thanks for this _significantly_ easier to use vagrant config for Ghost. I updated the Ghost version to the latest 0.4.0 release and it seems to work fine. 
